### PR TITLE
No generic ammo for Bolter ammo

### DIFF
--- a/Mods/1.4/CombatExtended/Defs/Ammo/Bolter.xml
+++ b/Mods/1.4/CombatExtended/Defs/Ammo/Bolter.xml
@@ -19,7 +19,6 @@
 			<Ammo_Bolter75_GF_MetalStorm>Bullet_Bolter75_GF_MetalStorm</Ammo_Bolter75_GF_MetalStorm>
 			<Ammo_Bolter75_GF_Kraken>Bullet_Bolter75_GF_Kraken</Ammo_Bolter75_GF_Kraken>
 		</ammoTypes>
-		<similarTo>AmmoSet_AntiMateriel</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
@@ -31,7 +30,6 @@
 			<Ammo_Bolter75_GF_MetalStorm>Bullet_Bolter75_GF_MetalStorm_Relic</Ammo_Bolter75_GF_MetalStorm>
 			<Ammo_Bolter75_GF_Kraken>Bullet_Bolter75_GF_Kraken_Relic</Ammo_Bolter75_GF_Kraken>
 		</ammoTypes>
-		<similarTo>AmmoSet_AntiMateriel</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->


### PR DESCRIPTION
What it says on the tin, the ammo is custom and not conventional like normal firearm ammo so it does not make sense for it to have generic ammo which causes issues without the Bolter ammo having its own custom tailored generic ammo which in the end would be exactly the same as the existing ammo.