### PR TITLE
Fixes to Stabber Ammo CE Patch

### DIFF
--- a/Mods/1.4/CombatExtended/Defs/Ammo/Stabber.xml
+++ b/Mods/1.4/CombatExtended/Defs/Ammo/Stabber.xml
@@ -97,7 +97,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="AmmoStabber_GFBase" ParentName="BaseBulletCE" Abstract="true">
+	<ThingDef Name="BulletStabber_GFBase" ParentName="BaseBulletCE" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="AmmoStabber_GFBase">
+	<ThingDef ParentName="BulletStabber_GFBase">
 		<defName>Bullet_Stabber_GF_Standard</defName>
 		<label>stabber standart bullet</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="AmmoStabber_GFBase">
+	<ThingDef ParentName="BulletStabber_GFBase">
 		<defName>Bullet_Stabber_GF_AP</defName>
 		<label>stabber AP bullet</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -130,7 +130,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="AmmoStabber_GFBase">
+	<ThingDef ParentName="BulletStabber_GFBase">
 		<defName>Bullet_Stabber_GF_HP</defName>
 		<label>stabber HP bullet</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -140,7 +140,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="AmmoStabber_GFBase">
+	<ThingDef ParentName="BulletStabber_GFBase">
 		<defName>Bullet_Stabber_GF_Incendiary</defName>
 		<label>stabber incendiary bullet</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Mods/1.4/CombatExtended/Defs/Ammo/Stabber.xml
+++ b/Mods/1.4/CombatExtended/Defs/Ammo/Stabber.xml
@@ -41,7 +41,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoStabber_GFBase">
 		<defName>Ammo_Stabber_Standard</defName>
-		<label>stabber standart round</label>
+		<label>stabber standard round</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -112,7 +112,7 @@
 
 	<ThingDef ParentName="BulletStabber_GFBase">
 		<defName>Bullet_Stabber_GF_Standard</defName>
-		<label>stabber standart bullet</label>
+		<label>stabber standard bullet</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
 			<armorPenetrationSharp>6.5</armorPenetrationSharp>
@@ -160,9 +160,9 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_Stabber_Standard</defName>
-		<label>make standart stabber rounds x500</label>
-		<description>Craft 500 standart stabber rounds.</description>
-		<jobString>Making standart stabber rounds.</jobString>
+		<label>make standard stabber rounds x500</label>
+		<description>Craft 500 standard stabber rounds.</description>
+		<jobString>Making standard stabber rounds.</jobString>
 		<ingredients>
 			<li>
 				<filter>


### PR DESCRIPTION
The base stabber projectile ThingDef in the Stabber Ammo CE Patch had the same "Name" attribute as the ammo ThingDef did ("AmmoStabber_GFBase"). This meant that the projectile defs for the stabber weren't loading and it was throwing these errors in the console.

https://media.discordapp.net/attachments/854372685446250517/1164748931830394960/image.png?ex=654457f9&is=6531e2f9&hm=8f116a33f510ffe04c2306f87bc48a21b290e87f71753bf7b2a9e3b7b4043034&=

By changing the name of the Projectile from "AmmoStabber_GFBase" to "BulletStabber_GFBase" it fixes the errors and the Stub weapons now work properly with CE

I've also changed the spelling in some of the labels/description from standart to standard